### PR TITLE
Implement further network tests

### DIFF
--- a/tests/test_userspace.py
+++ b/tests/test_userspace.py
@@ -24,22 +24,6 @@ def test_system_running_1(system1_shell):
     system_running(system1_shell)
 
 
-@pytest.mark.lg_feature("ptx-flavor")
-def test_nfs_mounts(env, target, shell):
-    """Test that the NFS mounts listed in the environment config are available."""
-    ptx_works = env.config.get_target_option(target.name, "ptx-works-available")
-
-    mount = shell.run_check("mount")
-    mount = "\n".join(mount)
-
-    for ptx_work in ptx_works:
-        assert ptx_work in mount
-
-        dir_contents = shell.run_check(f"ls -1 {ptx_work}")
-        # make sure the directories contain something
-        assert len(dir_contents) > 0
-
-
 def test_chrony(shell):
     """Test that chronyd is running and synchronized."""
     [chronyc] = shell.run_check("chronyc -c tracking")


### PR DESCRIPTION
Extend the test suite by two network tests:

- The NFS test case was moved to the network section as it is more related to network than userspace. Furthermore, it was extended by checking simple IO operations. This makes the test case more accurate as it now only passes when there are proper access permissions available.

- The HTTP IO test is similar in that it will check whether it is possible to download a file. The test coverage is thus extended by not only checking if the web server is reachable but additionally to check whether accessing files via the HTTP GET method is possible.