### PR TITLE
test_hardware: Use (new) static SPI bus numbers

### DIFF
--- a/tests/test_linux_hardware.py
+++ b/tests/test_linux_hardware.py
@@ -38,11 +38,11 @@ def test_linux_i2c_bus_2_pmic(shell):
     assert name == "stpmic1"
 
 
-def test_linux_spi_0_ethernet_switch(shell):
+def test_linux_spi_2_ethernet_switch(shell):
     """
-    Test if the Ethernet switch on spi-0 works.
+    Test if the Ethernet switch on spi-2 works.
     """
-    shell.run_check("test -d /sys/bus/spi/devices/spi0.0")
+    shell.run_check("test -d /sys/bus/spi/devices/spi2.0")
 
     # Statistics for the uplink interface are read from the Ethernet switch using spi0.
     # So a non-zero value will indicate that the device on the bus works.
@@ -50,26 +50,26 @@ def test_linux_spi_0_ethernet_switch(shell):
     assert int(rx_packets.split(":")[-1]) > 0
 
 
-def test_linux_spi_1_adc(shell):
+def test_linux_spi_0_adc(shell):
     """
-    Test if the ADC on spi-1 works.
+    Test if the ADC on spi-0 works.
     """
 
     # The voltage on power board switch is very likely not zero.
     # So if we can ready anything else, SPI to the ADC very likely works.
     # (Also: the tacd tests using these measurements would very likely fail.)
-    [digits] = shell.run_check(r"cat /sys/bus/spi/devices/spi1.0/iio\:device3/in_voltage_raw")
+    [digits] = shell.run_check(r"cat /sys/bus/spi/devices/spi0.0/iio\:device3/in_voltage_raw")
     assert int(digits) > 0
 
 
-def test_linux_spi_2_lcd(shell):
+def test_linux_spi_1_lcd(shell):
     """
-    Test if the framebuffer for the LCD on spi-2 exists.
+    Test if the framebuffer for the LCD on spi-1 exists.
     """
 
     # This is not a test of the SPI device itself, since we do not get any feedback from the display.
     # But this way, we at least know that the correct drm device has been probed.
-    [name] = shell.run_check("cat /sys/bus/spi/devices/spi2.0/graphics/fb0/name")
+    [name] = shell.run_check("cat /sys/bus/spi/devices/spi1.0/graphics/fb0/name")
     assert name == "panel-mipi-dbid"
 
 


### PR DESCRIPTION
The SPI bus order has seemingly shifted by one position with the update to kernel 6.11, resulting in the following build errors:

    05:45:11 FAILED tests/test_linux_hardware.py::test_linux_spi_1_adc - labgrid.driver.exception.ExecutionError: ('cat /sys/bus/spi/devices/spi1.0/iio\\:device3/in_voltage_raw', ["cat: '/sys/bus/spi/devices/spi1.0/iio:device3/in_voltage_raw': No such file or directory"], [])
    05:45:11 FAILED tests/test_linux_hardware.py::test_linux_spi_2_lcd - labgrid.driver.exception.ExecutionError: ('cat /sys/bus/spi/devices/spi2.0/graphics/fb0/name', ['cat: /sys/bus/spi/devices/spi2.0/graphics/fb0/name: No such file or directory'], [])

I've marked this PR as a draft since just adapting to the new order and hoping that it does not change again is a bit of a hack.
We should check first if we can make the bus number assignment stable before we change it here.