### PR TITLE
test_hardware: update the i2c bus numbers

### DIFF
--- a/tests/test_linux_hardware.py
+++ b/tests/test_linux_hardware.py
@@ -11,30 +11,30 @@ def test_linux_i2c_bus_0_eeprom(shell):
     assert magic == "xolcIQ=="
 
 
-def test_linux_i2c_bus_1_usbhub(shell):
+def test_linux_i2c_bus_2_usbhub(shell):
     """
-    Test if a driver for the USB hub on i2cbus-1 has been loaded.
+    Test if a driver for the USB hub on i2cbus-2 has been loaded.
     """
 
-    [name] = shell.run_check("cat /sys/bus/i2c/devices/i2c-1/1-002c/name")
+    [name] = shell.run_check("cat /sys/bus/i2c/devices/2-002c/name")
     assert name == "usb2514b"
 
 
-def test_linux_i2c_bus_2_eeprom(shell):
+def test_linux_i2c_bus_1_eeprom(shell):
     """
-    Test if the config EEPROM on i2cbus-2 can be read.
+    Test if the config EEPROM on i2cbus-1 can be read.
     """
 
     # the first 4 bytes of the EEPROM will always contain the magic for the TLV data stored in there
-    [magic] = shell.run_check("dd if=/sys/bus/i2c/devices/2-0050/eeprom bs=1 count=4 status=none | base64")
+    [magic] = shell.run_check("dd if=/sys/bus/i2c/devices/1-0050/eeprom bs=1 count=4 status=none | base64")
     assert magic == "vCiN/g=="
 
 
-def test_linux_i2c_bus_2_pmic(shell):
+def test_linux_i2c_bus_1_pmic(shell):
     """
-    Test if a driver for the PMIC on i2cbus-2 has been loaded.
+    Test if a driver for the PMIC on i2cbus-1 has been loaded.
     """
-    [name] = shell.run_check("cat /sys/bus/i2c/devices/i2c-2/2-0033/name")
+    [name] = shell.run_check("cat /sys/bus/i2c/devices/1-0033/name")
     assert name == "stpmic1"
 
 

--- a/tests/test_linux_hardware.py
+++ b/tests/test_linux_hardware.py
@@ -11,15 +11,6 @@ def test_linux_i2c_bus_0_eeprom(shell):
     assert magic == "xolcIQ=="
 
 
-def test_linux_i2c_bus_2_usbhub(shell):
-    """
-    Test if a driver for the USB hub on i2cbus-2 has been loaded.
-    """
-
-    [name] = shell.run_check("cat /sys/bus/i2c/devices/2-002c/name")
-    assert name == "usb2514b"
-
-
 def test_linux_i2c_bus_1_eeprom(shell):
     """
     Test if the config EEPROM on i2cbus-1 can be read.
@@ -38,16 +29,13 @@ def test_linux_i2c_bus_1_pmic(shell):
     assert name == "stpmic1"
 
 
-def test_linux_spi_2_ethernet_switch(shell):
+def test_linux_i2c_bus_2_usbhub(shell):
     """
-    Test if the Ethernet switch on spi-2 works.
+    Test if a driver for the USB hub on i2cbus-2 has been loaded.
     """
-    shell.run_check("test -d /sys/bus/spi/devices/spi2.0")
 
-    # Statistics for the uplink interface are read from the Ethernet switch using spi0.
-    # So a non-zero value will indicate that the device on the bus works.
-    [rx_packets] = shell.run_check("ethtool -S uplink  | grep rx_packets")
-    assert int(rx_packets.split(":")[-1]) > 0
+    [name] = shell.run_check("cat /sys/bus/i2c/devices/2-002c/name")
+    assert name == "usb2514b"
 
 
 def test_linux_spi_0_adc(shell):
@@ -71,6 +59,18 @@ def test_linux_spi_1_lcd(shell):
     # But this way, we at least know that the correct drm device has been probed.
     [name] = shell.run_check("cat /sys/bus/spi/devices/spi1.0/graphics/fb0/name")
     assert name == "panel-mipi-dbid"
+
+
+def test_linux_spi_2_ethernet_switch(shell):
+    """
+    Test if the Ethernet switch on spi-2 works.
+    """
+    shell.run_check("test -d /sys/bus/spi/devices/spi2.0")
+
+    # Statistics for the uplink interface are read from the Ethernet switch using spi0.
+    # So a non-zero value will indicate that the device on the bus works.
+    [rx_packets] = shell.run_check("ethtool -S uplink  | grep rx_packets")
+    assert int(rx_packets.split(":")[-1]) > 0
 
 
 def test_sensors(shell):


### PR DESCRIPTION
The meta-lxatac PR https://github.com/linux-automation/meta-lxatac/pull/205 has not only changed the SPI bus numbering but also the i2c bus numbers.

Update the tests to match these new (stable) bus numbers.