### PR TITLE
Record some more measurements during tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
+import contextlib
 import json
 import traceback
+from time import monotonic
 
 import pytest
 
@@ -90,6 +92,25 @@ def eet(strategy):
     yield eet
     if eet:
         eet.link("")
+
+
+@pytest.fixture(scope="function")
+def log_duration(record_property):
+    """
+    Allows to log the duration of a context as a property of the executed test.
+    This can be used to measure the duration of specific commands and write the result to the junitXML.
+    Use this fixture as a context manager:
+    > with log_duration("property-name"):
+    >     time.sleep(1)
+    """
+
+    @contextlib.contextmanager
+    def duration_logger(name: str):
+        start = monotonic()
+        yield
+        record_property(name, monotonic() - start)
+
+    return duration_logger
 
 
 def pytest_configure(config):

--- a/tests/test_linux_hardware.py
+++ b/tests/test_linux_hardware.py
@@ -73,9 +73,10 @@ def test_linux_spi_2_ethernet_switch(shell):
     assert int(rx_packets.split(":")[-1]) > 0
 
 
-def test_sensors(shell):
+def test_sensors(shell, record_property):
     stdout = shell.run_check("sensors -j")
     data = json.loads("".join(stdout))
 
     assert "cpu_thermal-virtual-0" in data
+    record_property("cpu_thermal-virtual-0", data["cpu_thermal-virtual-0"]["temp1"]["temp1_input"])
     assert 10 <= data["cpu_thermal-virtual-0"]["temp1"]["temp1_input"] <= 70

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -79,7 +79,7 @@ def test_network_tftp(prepare_network, shell, log_duration):
     "bandwidth, expected",
     ((10, pytest.approx(9, rel=0.1)), (100, pytest.approx(90, rel=0.1)), (1000, pytest.approx(350, rel=0.1))),
 )
-def test_network_performance(prepare_network, shell, bandwidth, expected):
+def test_network_performance(prepare_network, shell, record_property, bandwidth, expected):
     """Test network performance via iperf3"""
 
     try:
@@ -99,6 +99,7 @@ def test_network_performance(prepare_network, shell, bandwidth, expected):
             results = json.loads("".join(stdout), strict=False)
 
             mbps_received = results["end"]["sum_received"]["bits_per_second"] / 1e6
+            record_property(f"actual-bandwidth-{bandwidth}", mbps_received)
             assert mbps_received == expected
 
     finally:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -39,7 +39,7 @@ def prepare_network(strategy, shell):
 
 
 @pytest.mark.lg_feature("ethmux")
-def test_network_tftp(prepare_network, shell):
+def test_network_tftp(prepare_network, shell, log_duration):
     """Test tftp functionality"""
 
     try:
@@ -54,10 +54,12 @@ def test_network_tftp(prepare_network, shell):
         assert len(checksum1) > 0
 
         # Upload file to tftp server
-        shell.run_check("ip netns exec dut-namespace tftp -p -r ./test_file 10.11.12.2", timeout=35)
+        with log_duration("tftp put"):
+            shell.run_check("ip netns exec dut-namespace tftp -p -r ./test_file 10.11.12.2", timeout=35)
 
         # Download file from tftp server
-        shell.run_check("ip netns exec dut-namespace tftp -g -r test_file 10.11.12.2", timeout=35)
+        with log_duration("tftp get"):
+            shell.run_check("ip netns exec dut-namespace tftp -g -r test_file 10.11.12.2", timeout=35)
 
         # Generate checksum
         checksum2 = shell.run_check("md5sum ./test_file")

--- a/tests/test_rauc.py
+++ b/tests/test_rauc.py
@@ -60,7 +60,7 @@ def test_rauc_info_json(shell, rauc_bundle):
 
 @pytest.mark.slow
 @pytest.mark.dependency()
-def test_rauc_install(strategy, booted_slot, set_bootstate_in_bootloader, rauc_bundle):
+def test_rauc_install(strategy, booted_slot, set_bootstate_in_bootloader, rauc_bundle, log_duration):
     """
     Test if a rauc install from slot0 into slot1 works.
     """
@@ -77,7 +77,8 @@ def test_rauc_install(strategy, booted_slot, set_bootstate_in_bootloader, rauc_b
 
     # Actual installation - may take a few minutes.
     # Thus, let's use a large timeout.
-    strategy.shell.run_check(f"rauc install {rauc_bundle()}", timeout=600)
+    with log_duration("rauc install duration"):
+        strategy.shell.run_check(f"rauc install {rauc_bundle()}", timeout=600)
 
     # Power cycle and reboot into the new system.
     strategy.transition("off")


### PR DESCRIPTION
This PR adds some more properties with measurements to the junit-XML.
The values for the `test_network_tftp` and `test_network_performance` tests are values that have actually produced flaky tests in the past.
The other values are added precautionary. 