### PR TITLE
ptx-flavor: Test if at least one SSH-key is in the image

### DIFF
--- a/tests/test_userspace.py
+++ b/tests/test_userspace.py
@@ -163,3 +163,12 @@ def test_clocktree(clocktree, check, clock_name, rate, consumer):
     for c in consumer:
         with check:
             assert c in clk.consumer
+
+
+@pytest.mark.lg_feature("ptx-flavor")
+def test_ptx_ssh_keys(shell):
+    """
+    Check if there is at least one SSH key in the auto-generated authorized_keys.
+    This file is generated in our internal flavor of meta-lxatac and contains all relevant keys from our ansible.
+    """
+    shell.run_check('grep -q "^ssh-" /etc/ssh/authorized_keys.root')


### PR DESCRIPTION
We have an internal flavor of meta-lxatac in which our devel's ssh-keys are pre-defined in our image. Make sure that at least one key is in the image, so that the magic generating the file ran successfully.