### PR TITLE
tests/test_linux_log: remove messages that went away in Linux 6.15

### DIFF
--- a/tests/test_linux_log.py
+++ b/tests/test_linux_log.py
@@ -21,7 +21,6 @@ def test_kernel_messages(shell, check):
         "spi_stm32 44009000.spi: failed to request tx dma channel",
         "spi_stm32 44009000.spi: failed to request rx dma channel",
         "clk: failed to reparent ethck_k to pll4_p: -22",
-        "OF: /soc/bus@5c007000/adc@48003000: Read of boolean property 'vdd-supply' with a value.",
         "stm32-dwmac 5800a000.ethernet switch: Adding VLAN ID 0 is not supported",
     }
 


### PR DESCRIPTION
The source of this warning was removed in commit https://github.com/torvalds/linux/commit/a4a947a741905, which is included in Version 6.15-rc1 and onward.