### PR TITLE
tests/can: Test berr-counter resetting

### DIFF
--- a/tests/test_interfaces_can.py
+++ b/tests/test_interfaces_can.py
@@ -62,12 +62,6 @@ def test_can_tools(shell):
     shell.run_check("which cansend")
 
 
-@pytest.mark.xfail(
-    reason="We currently suspect the Socketcan MCAN driver to not reliably reset the berr-counter on if-down on 6.10. "
-    "At least can0_iobus is usually in an error state, since there is no other (active) CAN-node on the bus until "
-    "can1 is set up. "
-    "Thus the test fails most of the time."
-)
 @pytest.mark.lg_feature("eet")
 def test_can_traffic(shell, can_configured):
     """


### PR DESCRIPTION
With https://github.com/linux-automation/meta-lxatac/pull/284 we can now reset the berr-counters in the can peripherals - as long as we set both down.

This should make the `test_can_traffic` work reliably again, so drop the `xfail`.

But also add an test to explicitly test that the reset works.