### PR TITLE
tests/can: test_can_berr_reset: berr_counters can go above 128

### DIFF
--- a/tests/test_interfaces_can.py
+++ b/tests/test_interfaces_can.py
@@ -100,7 +100,7 @@ def test_can_berr_reset(shell, can_configured, can_interface):
     [if_state] = shell.run_check(f"ip -detail -json link show {can_interface}")
     [if_state] = json.loads(if_state)
     assert if_state["linkinfo"]["info_data"]["state"] == "ERROR-PASSIVE"
-    assert if_state["linkinfo"]["info_data"]["berr_counter"]["tx"] == 128
+    assert if_state["linkinfo"]["info_data"]["berr_counter"]["tx"] >= 128
 
     # Setting the interface down should reset the counter:
     shell.run_check(f"ip link set {can_interface} down")


### PR DESCRIPTION
As marckleinebudde pointed out, the error counters can also go above 128:
https://github.com/linux-automation/labgrid-lxatac/pull/16#discussion_r2340504258

So let's make sure every value >= 128 is fine.