### PR TITLE
New dmesg messages in Linux 6.17 and relax measurement timing

### DIFF
--- a/tests/test_linux_log.py
+++ b/tests/test_linux_log.py
@@ -21,6 +21,9 @@ def test_kernel_messages(shell, check):
         "spi_stm32 44009000.spi: failed to request tx dma channel",
         "spi_stm32 44009000.spi: failed to request rx dma channel",
         "clk: failed to reparent ethck_k to pll4_p: -22",
+        "dwc2 49000000.usb-otg: supply vusb_d not found, using dummy regulator",
+        "dwc2 49000000.usb-otg: supply vusb_a not found, using dummy regulator",
+        "check access for rdinit=/init failed: -2, ignoring",
         "stm32-dwmac 5800a000.ethernet switch: Adding VLAN ID 0 is not supported",
     }
 

--- a/tests/test_tacd.py
+++ b/tests/test_tacd.py
@@ -257,7 +257,7 @@ def test_tacd_dut_power_switchable(strategy, shell, eet, record_property, check)
     )  # Connect PWRin to 12V. Load PWRout with 15R
     r = requests.put(f"http://{strategy.network.address}/v1/dut/powered", data=b'"On"')  # activate DUT power switch
     assert r.status_code == 204
-    time.sleep(0.1)  # Give measurements a moment to settle
+    time.sleep(0.5)  # Give measurements a moment to settle
 
     r = requests.get(f"http://{strategy.network.address}/v1/dut/feedback/current")  # measure DUT current
     assert r.status_code == 200


### PR DESCRIPTION
Two changes to the testsuite:

---

### `tests/test_linux_log: add new expected messages`

These were introduced in:

- "check access for rdinit=/init failed: -2, ignoring"

  Linux Kernel Commit 98aa4d5d242d3 ("init/main.c: add warning when file
  specified in rdinit is inaccessible") which at a first glance seems to
  assume that there should always be an initramfs?

- "dwc2 49000000.usb-otg: supply vusb_d not found, using dummy regulator"
  "dwc2 49000000.usb-otg: supply vusb_a not found, using dummy regulator"

   A patch by Ahmad[1] that solves sporadic boot hangs, at least on older
   kernels.

---

### `test/test_tacd_dut_power_switchable: Increase analog waiting time`

This aligns with other increased delays like e.g. the one in commit a518273 ("test/test_tacd_dut_power_off_floating: Increase analog waiting time").

This was the only place where we still had 0.1s of delay and this is a location where we sometimes see issues with failed assertions.