### PR TITLE
strategy/post-mortem: Tell systemd not to use a pager

### DIFF
--- a/lxatacstrategy.py
+++ b/lxatacstrategy.py
@@ -229,6 +229,6 @@ class LXATACStrategy(Strategy):
             get_info(self.shell, "ip -brief -6 route")
             get_info(self.shell, "df --human-readable")
             get_info(self.shell, "free -m")
-            get_info(self.shell, "systemctl list-units --failed")
+            get_info(self.shell, "systemctl list-units --failed --no-pager")
 
         return pm_info


### PR DESCRIPTION
Without `--no-pager` systemctl may decide to present us with a pager instead of the actual output.
This is a no-go in a labgrid-test since the shell-driver does not know about pager and will not be able to recover shell access.