### PR TITLE
lxatac-*: update location of the tf-a

### DIFF
--- a/lxatac-ptx.yaml
+++ b/lxatac-ptx.yaml
@@ -64,7 +64,7 @@ targets:
       - eet
 
 images:
-  tfa: ../images/lxatac/tf-a-stm32mp157c-lxa-tac.stm32
+  tfa: ../images/lxatac/trusted-firmware-a/tf-a-stm32mp157c-lxa-tac.stm32
   mmc_boot_fip: ../images/lxatac/emmc-boot-image-lxatac.fip
   mmc_boot: ../images/lxatac/emmc-boot-image-lxatac.img
   mmc: ../images/lxatac/emmc-image-lxatac.simg

--- a/lxatac-vanilla-eet.yaml
+++ b/lxatac-vanilla-eet.yaml
@@ -47,7 +47,7 @@ targets:
       - ethmux
 
 images:
-  tfa: ../images/lxatac/tf-a-stm32mp157c-lxa-tac.stm32
+  tfa: ../images/lxatac/trusted-firmware-a/tf-a-stm32mp157c-lxa-tac.stm32
   mmc_boot_fip: ../images/lxatac/emmc-boot-image-lxatac.fip
   mmc_boot: ../images/lxatac/emmc-boot-image-lxatac.img
   mmc: ../images/lxatac/emmc-image-lxatac.simg

--- a/lxatac-vanilla.yaml
+++ b/lxatac-vanilla.yaml
@@ -35,7 +35,7 @@ targets:
       ptx-works-available: []
 
 images:
-  tfa: ../images/lxatac/tf-a-stm32mp157c-lxa-tac.stm32
+  tfa: ../images/lxatac/trusted-firmware-a/tf-a-stm32mp157c-lxa-tac.stm32
   mmc_boot_fip: ../images/lxatac/emmc-boot-image-lxatac.fip
   mmc_boot: ../images/lxatac/emmc-boot-image-lxatac.img
   mmc: ../images/lxatac/emmc-image-lxatac.simg


### PR DESCRIPTION
With the wrynose update the location of the tf-a has changed, it is now located in a `trusted-firmware-a` subdirectory.

Update the paths accordingly.