### PR TITLE
Tests originating from the Cysec Risk Assessment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 
 pytest-check
 pytest-dependency
+paho-mqtt

--- a/tests/test_tacd.py
+++ b/tests/test_tacd.py
@@ -384,3 +384,56 @@ def test_tacd_iobus_power_switchable(strategy, shell, eet, record_property, chec
     assert r.status_code == 200
     record_property("Off -> Voltage", r.json()["value"])
     assert -0.5 < r.json()["value"] < 0.5
+
+
+@pytest.fixture(scope="function")
+def tacd_configured(shell: labgrid.driver.ShellDriver):
+    """
+    Make sure the tacd is in a configured mode and restore the previous state after the test has run.
+    """
+
+    original_state_file = shell.get_bytes("/srv/tacd/state.json").decode()
+    state = json.loads(original_state_file)
+    if not state["persistent_topics"]["/v1/tac/setup_mode"]:
+        # We are already set up. Nothing to do.
+        yield
+        return
+
+    state["persistent_topics"]["/v1/tac/setup_mode"] = False
+    new_state_file = json.dumps(state)
+    shell.put_bytes(new_state_file.encode(), "/srv/tacd/state.json")
+    shell.run_check("systemctl restart tacd")
+    yield
+    shell.put_bytes(original_state_file.encode(), "/srv/tacd/state.json")
+    shell.run_check("systemctl restart tacd")
+
+
+def test_tacd_ssh_pubkeys_not_writeable_http(shell, strategy, tacd_configured):
+    """
+    Make sure we can not get or set the authorized_keys using the HTTP API in the tacd.
+
+    @relation(CySec4, scope=function)
+    """
+    # Make sure setup mode is disabled
+    r = requests.get(f"http://{strategy.network.address}/v1/tac/setup_mode")
+    assert r.status_code == 200
+    assert r.text == "false"
+
+    # We should not be able to retrieve SSH keys outside of setup mode
+    r = requests.get(f"http://{strategy.network.address}/v1/tac/ssh/authorized_keys")
+    assert r.status_code == 403
+    assert r.text == "This file may only be read in setup mode"
+
+    magic_string = "NO_SSH_KEY"
+    # Make sure the authorized_keys isn't accidentally already set to our magic string
+    with contextlib.suppress(labgrid.driver.shelldriver.ExecutionError):
+        assert shell.get_bytes("/root/.ssh/authorized_keys").decode() != magic_string
+
+    # We should not be able to PUT SSH keys outside of setup mode
+    r = requests.put(f"http://{strategy.network.address}/v1/tac/ssh/authorized_keys", data=magic_string)
+    assert r.status_code == 403
+    assert r.text == "This file may only be written in setup mode"
+
+    # Make sure the authorized_keys has not been written even if the HTTP status message tells otherwise
+    with contextlib.suppress(labgrid.driver.shelldriver.ExecutionError):
+        assert shell.get_bytes("/root/.ssh/authorized_keys").decode() != magic_string

--- a/tests/test_tacd.py
+++ b/tests/test_tacd.py
@@ -1,8 +1,14 @@
+import contextlib
 import json
 import time
+from collections.abc import Callable, Generator
+from typing import Any
 
+import labgrid.driver
+import paho.mqtt.client as mqtt
 import pytest
 import requests
+from labgrid.util import Timeout
 
 
 def test_tacd_http_temperature(strategy, shell):
@@ -433,6 +439,69 @@ def test_tacd_ssh_pubkeys_not_writeable_http(shell, strategy, tacd_configured):
     r = requests.put(f"http://{strategy.network.address}/v1/tac/ssh/authorized_keys", data=magic_string)
     assert r.status_code == 403
     assert r.text == "This file may only be written in setup mode"
+
+    # Make sure the authorized_keys has not been written even if the HTTP status message tells otherwise
+    with contextlib.suppress(labgrid.driver.shelldriver.ExecutionError):
+        assert shell.get_bytes("/root/.ssh/authorized_keys").decode() != magic_string
+
+
+@pytest.fixture(scope="function")
+def ws_mqtt(strategy) -> Generator[tuple[mqtt.Client, dict[Any, Any], Callable[..., str]], Any, None]:
+    """
+    Sets up a threaded paho-mqtt client that is connected to the websocket-mqtt endpoint of the tacd.
+
+    Since paho-mqtt is event-driven by design and this does not go very well with linear tests this fixture also
+    provides a wrapper around  paho-mqtt that allows a test to retrieve the last value of each topic.
+    """
+    last_values = dict()
+
+    def _on_message(client, userdata, msg):
+        last_values[msg.topic] = msg.payload.decode()
+
+    def get_value(topic: str) -> str:
+        t = Timeout(timeout=1.0)
+        while not t.expired:
+            if topic in last_values:
+                return last_values.pop(topic)
+            time.sleep(0.1)
+        else:
+            raise TimeoutError("Topic not found until timeout")
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, transport="websockets")
+    client.on_message = _on_message
+    client.ws_set_options(path="/v1/mqtt")
+    client.connect(f"{strategy.network.address}", 80)
+    client.loop_start()
+    connect_timeout = Timeout(timeout=5.0)
+    while not connect_timeout.expired:
+        if client.is_connected():
+            break
+        time.sleep(0.1)
+    else:
+        raise ConnectionError("Could not connect to tacd mqtt-ws in time!")
+    yield client, last_values, get_value
+    client.disconnect()
+
+
+def test_tacd_ssh_pubkeys_not_writeable_ws(shell, tacd_configured, ws_mqtt):
+    """
+    Make sure we can not set the authorized_keys using the Websocket in the tacd.
+
+    @relation(CySec4, scope=function)
+    """
+    client, last_values, get_value = ws_mqtt
+
+    # Make sure setup mode is disabled
+    client.subscribe("/v1/tac/setup_mode")
+    assert get_value("/v1/tac/setup_mode") == "false"
+
+    magic_string = "NO_SSH_KEY"
+    # Make sure the authorized_keys isn't accidentally already set to our magic string
+    with contextlib.suppress(labgrid.driver.shelldriver.ExecutionError):
+        assert shell.get_bytes("/root/.ssh/authorized_keys").decode() != magic_string
+
+    # We should not be able to PUT SSH keys outside of setup mode
+    client.publish("/v1/tac/ssh/authorized_keys", magic_string, qos=0, retain=True)
 
     # Make sure the authorized_keys has not been written even if the HTTP status message tells otherwise
     with contextlib.suppress(labgrid.driver.shelldriver.ExecutionError):

--- a/tests/test_tacd.py
+++ b/tests/test_tacd.py
@@ -506,3 +506,47 @@ def test_tacd_ssh_pubkeys_not_writeable_ws(shell, tacd_configured, ws_mqtt):
     # Make sure the authorized_keys has not been written even if the HTTP status message tells otherwise
     with contextlib.suppress(labgrid.driver.shelldriver.ExecutionError):
         assert shell.get_bytes("/root/.ssh/authorized_keys").decode() != magic_string
+
+
+def test_tacd_no_setup_mode_http(shell, strategy, tacd_configured):
+    """
+    Make sure we can not enter setup mode via the HTTP API.
+
+    @relation(CySec5, scope=function)
+    """
+
+    # Make sure setup mode is disabled
+    r = requests.get(f"http://{strategy.network.address}/v1/tac/setup_mode")
+    assert r.status_code == 200
+    assert r.text == "false"
+
+    # Try to activate config mode
+    r = requests.put(f"http://{strategy.network.address}/v1/tac/setup_mode", data="true")
+    assert r.status_code == 204
+
+    # Make sure setup mode is still disabled
+    r = requests.get(f"http://{strategy.network.address}/v1/tac/setup_mode")
+    assert r.status_code == 200
+    assert r.text == "false"
+
+
+def test_tacd_no_setup_mode_ws(shell, strategy, tacd_configured, ws_mqtt):
+    """
+    Make sure we can not enter setup mode via the Websocket API.
+
+    @relation(CySec5, scope=function)
+    """
+    client, last_values, get_value = ws_mqtt
+
+    # Make sure setup mode is disabled
+    r = requests.get(f"http://{strategy.network.address}/v1/tac/setup_mode")
+    assert r.status_code == 200
+    assert r.text == "false"
+
+    # Try to activate config mode
+    client.publish("/v1/tac/setup_mode", "true", qos=0, retain=True)
+
+    # Make sure setup mode is still disabled
+    r = requests.get(f"http://{strategy.network.address}/v1/tac/setup_mode")
+    assert r.status_code == 200
+    assert r.text == "false"

--- a/tests/test_userspace.py
+++ b/tests/test_userspace.py
@@ -3,6 +3,7 @@ import json
 import re
 from dataclasses import dataclass
 
+import labgrid
 import pytest
 
 
@@ -185,3 +186,27 @@ def test_ssh_password_login_disabled(shell, strategy):
         f"StrictHostKeyChecking=no root@{strategy.network.address} 2>&1 | grep Authentications"
     )
     assert "debug1: Authentications that can continue: publickey" in [x.strip() for x in auth_methods]
+
+
+def test_ssh_no_pubkeys(shell, env: labgrid.Environment, check):
+    """
+    Make sure there are no SSH pubkeys present on the device.
+    This test aims to find ssh pubkeys that have been left on the device by accident, so we only check the most likely
+    locations in the file system.
+
+    @relation(CySec2, scope=function)
+    """
+
+    if "ptx-flavor" in env.get_target_features():
+        pytest.skip(reason="Test does not make sense for non-production image with ptx-flavor.")
+
+    # Check for authorized keys for all users.
+    # This way we can later add new users and this test will automatically pick them up.
+    homes = shell.run_check("cat /etc/passwd | cut -d':' -f 6")
+    for home in homes:
+        with check:
+            shell.run_check(f"test ! -f {home}/.ssh/authorized_keys")
+
+    # Check for the authorized keys from the ptx-flavor.
+    with check:
+        shell.run_check("test ! -f /etc/ssh/authorized_keys.root")

--- a/tests/test_userspace.py
+++ b/tests/test_userspace.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 import labgrid
 import pytest
+import requests
 
 
 def test_chrony(shell):
@@ -210,3 +211,64 @@ def test_ssh_no_pubkeys(shell, env: labgrid.Environment, check):
     # Check for the authorized keys from the ptx-flavor.
     with check:
         shell.run_check("test ! -f /etc/ssh/authorized_keys.root")
+
+
+def test_iobus_website(shell, strategy):
+    """
+    Test if the LXA IOBus server serves it's website.
+    """
+    r = requests.get(f"http://{strategy.network.address}:8080")
+    assert r.status_code == 200
+    assert "<title>LXA IOBus Server</title>" in r.text
+
+
+def test_iobus_server_state(shell, strategy, check):
+    """
+    Test if the LXA IOBus server reports a useful state.
+
+    In the test fixture there is no LXA IOBus node connected to the LXA TAC.
+    Thus can_tx_state will be "error" - but everything else should look normal.
+    """
+    r = requests.get(f"http://{strategy.network.address}:8080/server-info/")
+    assert r.status_code == 200
+
+    state = json.loads(r.text)
+
+    [hostname] = shell.run_check("hostname")
+
+    with check:
+        assert "hostname" in state and state["hostname"] == hostname
+
+    with check:
+        assert "can_interface" in state and state["can_interface"] == "can0_iobus"
+
+    with check:
+        assert "can_interface_is_up" in state and state["can_interface_is_up"]
+
+    with check:
+        assert "lss_state" in state and state["lss_state"] == "Idle"
+
+    with check:
+        assert "can_tx_error" in state and isinstance(state["can_tx_error"], bool)
+
+
+def test_iobus_server_api(shell, strategy, check):
+    """
+    Test if the LXA IOBus server reports a useful node list.
+
+    Since the testbed does not have an IOBus node connected we can only check, if the server actually reports an
+    empty node list.
+    """
+    r = requests.get(f"http://{strategy.network.address}:8080/nodes/")
+    assert r.status_code == 200
+
+    r = json.loads(r.text)
+
+    with check:
+        assert "code" in r and r["code"] == 0
+
+    with check:
+        assert "error_message" in r and r["error_message"] == ""
+
+    with check:
+        assert "result" in r and isinstance(r["result"], list) and not r["result"]

--- a/tests/test_userspace.py
+++ b/tests/test_userspace.py
@@ -272,3 +272,26 @@ def test_iobus_server_api(shell, strategy, check):
 
     with check:
         assert "result" in r and isinstance(r["result"], list) and not r["result"]
+
+
+def test_iobus_service_hardening(shell, check):
+    """
+    Test if the hardening options for the LXA IOBus server have been applied.
+
+    @relation(CySec8, scope=function)
+    """
+
+    def _assert_value(property_name: str, should: str) -> None:
+        value = shell.run_check(f"systemctl show -p {property_name} --value --no-pager lxa-iobus.service")
+        with check:
+            assert len(value) == 1  # len(value) == 0 would be an empty result.
+            assert value[0] == should
+
+    _assert_value("PrivateDevices", "yes")
+    _assert_value("PrivateTmp", "yes")
+    _assert_value("ProtectControlGroups", "yes")
+    _assert_value("ProtectKernelModules", "yes")
+    _assert_value("ProtectKernelTunables", "yes")
+    _assert_value("ProtectKernelLogs", "yes")
+    _assert_value("ProtectSystem", "strict")
+    _assert_value("ReadWritePaths", "/var/cache/lxa-iobus")

--- a/tests/test_userspace.py
+++ b/tests/test_userspace.py
@@ -172,3 +172,16 @@ def test_ptx_ssh_keys(shell):
     This file is generated in our internal flavor of meta-lxatac and contains all relevant keys from our ansible.
     """
     shell.run_check('grep -q "^ssh-" /etc/ssh/authorized_keys.root')
+
+
+def test_ssh_password_login_disabled(shell, strategy):
+    """
+    Check if the sshd running on the LXA TAC offers only "publickey" as authentication method.
+
+    @relation(CySec1, scope=function)
+    """
+    auth_methods = shell.run_check(
+        "ssh -v -o PreferredAuthentications=none -o UserKnownHostsFile=/dev/null -o "
+        f"StrictHostKeyChecking=no root@{strategy.network.address} 2>&1 | grep Authentications"
+    )
+    assert "debug1: Authentications that can continue: publickey" in [x.strip() for x in auth_methods]


### PR DESCRIPTION
This PR adds tests that originate from the Cysec Risk Assessment for the LXA TAC.
This touches three areas:

* SSH: Make sure only public key authentication is available and that we do not package any ssh pubkeys in the BSP - expect for the `ptx-flavor` that is intended to contain ssh pubkeys (but should never be shipped to customers).
* tacd: Make sure a user can only change the ssh pubkeys after they have proven physical presence at the device.
* IOBus Server: Test that the hardening-options in systemd are active (and add some basic tests while we are on it).

This PR contains the following PRs that need to be merged first:

* [x] #18 
* [x] #27 