### PR TITLE
tests: Change Strictdoc Tracking Marker to Correct Identifier

### DIFF
--- a/tests/test_tacd.py
+++ b/tests/test_tacd.py
@@ -429,7 +429,7 @@ def test_tacd_ssh_pubkeys_not_writeable_http(shell, strategy, tacd_configured):
     """
     Make sure we can not get or set the authorized_keys using the HTTP API in the tacd.
 
-    @relation(CySec4, scope=function)
+    @relation(CYSEC-4, scope=function)
     """
     # Make sure setup mode is disabled
     r = requests.get(f"http://{strategy.network.address}/v1/tac/setup_mode")
@@ -498,7 +498,7 @@ def test_tacd_ssh_pubkeys_not_writeable_ws(shell, tacd_configured, ws_mqtt):
     """
     Make sure we can not set the authorized_keys using the Websocket in the tacd.
 
-    @relation(CySec4, scope=function)
+    @relation(CYSEC-4, scope=function)
     """
     client, last_values, get_value = ws_mqtt
 
@@ -523,7 +523,7 @@ def test_tacd_no_setup_mode_http(shell, strategy, tacd_configured):
     """
     Make sure we can not enter setup mode via the HTTP API.
 
-    @relation(CySec5, scope=function)
+    @relation(CYSEC-5, scope=function)
     """
 
     # Make sure setup mode is disabled
@@ -545,7 +545,7 @@ def test_tacd_no_setup_mode_ws(shell, strategy, tacd_configured, ws_mqtt):
     """
     Make sure we can not enter setup mode via the Websocket API.
 
-    @relation(CySec5, scope=function)
+    @relation(CYSEC-5, scope=function)
     """
     client, last_values, get_value = ws_mqtt
 

--- a/tests/test_userspace.py
+++ b/tests/test_userspace.py
@@ -180,7 +180,7 @@ def test_ssh_password_login_disabled(shell, strategy):
     """
     Check if the sshd running on the LXA TAC offers only "publickey" as authentication method.
 
-    @relation(CySec1, scope=function)
+    @relation(CYSEC-1, scope=function)
     """
     auth_methods = shell.run_check(
         "ssh -v -o PreferredAuthentications=none -o UserKnownHostsFile=/dev/null -o "
@@ -195,7 +195,7 @@ def test_ssh_no_pubkeys(shell, env: labgrid.Environment, check):
     This test aims to find ssh pubkeys that have been left on the device by accident, so we only check the most likely
     locations in the file system.
 
-    @relation(CySec2, scope=function)
+    @relation(CYSEC-2, scope=function)
     """
 
     if "ptx-flavor" in env.get_target_features():
@@ -278,7 +278,7 @@ def test_iobus_service_hardening(shell, check):
     """
     Test if the hardening options for the LXA IOBus server have been applied.
 
-    @relation(CySec8, scope=function)
+    @relation(CYSEC-8, scope=function)
     """
 
     def _assert_value(property_name: str, should: str) -> None:


### PR DESCRIPTION
The CamelCase identifier was used by mistake and corrected in the strictdoc document over time.

To repair the tracking between test-code and requirement we need to update the identifier.