### PR TITLE
Check for IPv4 address and for a valid system clock

### DIFF
--- a/tests/test_userspace.py
+++ b/tests/test_userspace.py
@@ -71,6 +71,15 @@ def test_switch_configuration(shell, check):
     with check:
         assert global_v6.endswith(v6_tail)
 
+    # Check if we have at least one dynamic IPv4 address on tac-bridge
+    with check:
+        v4_addrs = [
+            ai["local"]
+            for ai in ip_addr_json["addr_info"]
+            if ai["family"] == "inet" and "dynamic" in ai and ai["dynamic"]
+        ]
+        assert len(v4_addrs), "No IPv4 addr configured via DHCP"
+
 
 def test_hostname(shell, check):
     """Test whether the serial number is contained in the hostname"""


### PR DESCRIPTION
While investigating a misbehaving device in our own fleet I discovered that it neither had an IPv4 address, nor a valid system time.
In the end the actual problem was unrelated to these symptoms and the root cause is still unknown. But these test at least verify that the symptoms are not present.