### PR TITLE
tests: RAUC: Ensure the correct signing-key is active

### DIFF
--- a/tests/test_rauc.py
+++ b/tests/test_rauc.py
@@ -1,5 +1,6 @@
 import json
 
+import labgrid
 import pytest
 
 """
@@ -34,16 +35,22 @@ def test_rauc_status(shell):
     shell.run_check("rauc status", timeout=60)
 
 
-def test_rauc_info_json(shell, rauc_bundle, check):
-    """
-    Test rauc info output in JSON for a rauc bundle read via http.
-    """
-
+@pytest.fixture(scope="function")
+def rauc_cert_enabled(shell, env: labgrid.Environment):
     # Bundles during testing are not signed with release keys.
     # But the development key is not enabled by default.
     # So we need to enable it first.
-    shell.run_check("rauc-enable-cert devel.cert.pem")
 
+    cert = "pengutronix.cert.pem" if "ptx-flavor" in env.get_target_features() else "devel.cert.pem"
+    shell.run_check(f"rauc-enable-cert {cert}")
+    yield
+    shell.run_check(f"rauc-disable-cert {cert}")
+
+
+def test_rauc_info_json(shell, rauc_bundle, check, rauc_cert_enabled):
+    """
+    Test rauc info output in JSON for a rauc bundle read via http.
+    """
     # Let rauc read the info for the rauc bundle.
     # The diversion via the tmp-file allows us to ignore any output on stderr that rauc may output.
     shell.run_check(f"rauc info {rauc_bundle()} --output-format=json > /tmp/rauc.json")
@@ -65,7 +72,9 @@ def test_rauc_info_json(shell, rauc_bundle, check):
 
 @pytest.mark.slow
 @pytest.mark.dependency()
-def test_rauc_install(strategy, booted_slot, set_bootstate_in_bootloader, rauc_bundle, log_duration):
+def test_rauc_install(
+    strategy, booted_slot, set_bootstate_in_bootloader, rauc_bundle, log_duration, rauc_cert_enabled
+):
     """
     Test if a rauc install from slot0 into slot1 works.
     """
@@ -74,11 +83,6 @@ def test_rauc_install(strategy, booted_slot, set_bootstate_in_bootloader, rauc_b
     set_bootstate_in_bootloader(20, 1, 10, 1)
     strategy.transition("shell")
     assert booted_slot() == "system0"
-
-    # Bundles during testing are not signed with release keys.
-    # But the development key is not enabled by default.
-    # So we need to enable it first.
-    strategy.shell.run_check("rauc-enable-cert devel.cert.pem")
 
     # Actual installation - may take a few minutes.
     # Thus, let's use a large timeout.


### PR DESCRIPTION
Bundles we build with our internal `ptx-flavor` are not signed with `devel.cert.pem`, but with an internal `penguronix.cert.pem`.

Activate the correct certificate before each test that needs an active valid certificate.

Moving the cert-activation into a fixture allows us to make sure the cert is disabled after a test run. This removes a side effect of `test_rauc_info_json()` and `test_rauc_install()` where after the test run the development certificate will stay enabled (and thus the system state changed).