### PR TITLE
tests: tacd,linux_hardware: update name of cpu sensor in sensors -j output

### DIFF
--- a/tests/test_linux_hardware.py
+++ b/tests/test_linux_hardware.py
@@ -82,9 +82,9 @@ def test_sensors(shell, record_property):
     stdout = shell.run_check("sensors -j")
     data = json.loads("".join(stdout))
 
-    assert "cpu_thermal-virtual-0" in data
-    record_property("cpu_thermal-virtual-0", data["cpu_thermal-virtual-0"]["temp1"]["temp1_input"])
-    assert 10 <= data["cpu_thermal-virtual-0"]["temp1"]["temp1_input"] <= 70
+    assert "cpu_thermal_0-virtual-0" in data
+    record_property("cpu_thermal_0-virtual-0", data["cpu_thermal_0-virtual-0"]["temp1"]["temp1_input"])
+    assert 10 <= data["cpu_thermal_0-virtual-0"]["temp1"]["temp1_input"] <= 70
 
 
 def test_linux_watchdog(strategy: LXATACStrategy, shell: labgrid.driver.ShellDriver):

--- a/tests/test_tacd.py
+++ b/tests/test_tacd.py
@@ -20,9 +20,9 @@ def test_tacd_http_temperature(strategy, shell):
 
     stdout = shell.run_check("sensors -j")
     data = json.loads("".join(stdout))
-    assert "cpu_thermal-virtual-0" in data
+    assert "cpu_thermal_0-virtual-0" in data
 
-    assert data["cpu_thermal-virtual-0"]["temp1"]["temp1_input"] == pytest.approx(temperature, abs=3)
+    assert data["cpu_thermal_0-virtual-0"]["temp1"]["temp1_input"] == pytest.approx(temperature, abs=3)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I did not investigate when the name of this sensor changed, but it did change and started breaking our tests.