### PR TITLE
RAUC: Refacor Fixtures and Ensure DUT State

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,4 @@
 import contextlib
-import json
 import traceback
 from time import monotonic
 
@@ -28,53 +27,6 @@ def shell(strategy):
         pytest.exit(f"Transition into shell failed: {e}", returncode=3)
 
     return strategy.shell
-
-
-@pytest.fixture
-def default_bootstate(strategy):
-    """Set default state values as setup/teardown"""
-    strategy.transition("barebox")
-    strategy.barebox.run_check("bootchooser -a default -p default")
-
-    yield
-
-    strategy.transition("barebox")
-    strategy.barebox.run_check("bootchooser -a default -p default")
-
-
-@pytest.fixture
-def booted_slot(strategy):
-    """Returns booted slot."""
-
-    def _booted_slot():
-        strategy.transition("shell")
-        [stdout] = strategy.shell.run_check("rauc status --output-format=json", timeout=60)
-        rauc_status = json.loads(stdout)
-
-        assert "booted" in rauc_status, 'No "booted" key in rauc status json found'
-
-        return rauc_status["booted"]
-
-    yield _booted_slot
-
-
-@pytest.fixture
-def set_bootstate_in_bootloader(strategy, default_bootstate):
-    """Sets the given bootchooser parameters."""
-
-    def _set_bootstate(system0_prio, system0_attempts, system1_prio, system1_attempts):
-        strategy.transition("barebox")
-        barebox = strategy.barebox
-
-        barebox.run_check(f"state.bootstate.system0.priority={system0_prio}")
-        barebox.run_check(f"state.bootstate.system0.remaining_attempts={system0_attempts}")
-
-        barebox.run_check(f"state.bootstate.system1.priority={system1_prio}")
-        barebox.run_check(f"state.bootstate.system1.remaining_attempts={system1_attempts}")
-
-        barebox.run_check("state -s")
-
-    yield _set_bootstate
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -43,11 +43,12 @@ def default_bootstate(strategy):
 
 
 @pytest.fixture
-def booted_slot(shell):
+def booted_slot(strategy):
     """Returns booted slot."""
 
     def _booted_slot():
-        [stdout] = shell.run_check("rauc status --output-format=json", timeout=60)
+        strategy.transition("shell")
+        [stdout] = strategy.shell.run_check("rauc status --output-format=json", timeout=60)
         rauc_status = json.loads(stdout)
 
         assert "booted" in rauc_status, 'No "booted" key in rauc status json found'

--- a/tests/test_rauc.py
+++ b/tests/test_rauc.py
@@ -21,20 +21,67 @@ is already a dependency of `set_bootstate_in_bootloader`.
 #  and write a test for that.
 
 
-def test_rauc_version(shell):
+@pytest.fixture
+def default_bootstate(strategy: LXATACStrategy):
     """
-    Test basic availability working of rauc binary by obtaining version
-    information
+    Set default state values as setup/teardown
+
+    Note: This fixture changes the state of the DUT using the strategy.
+    When using this fixture do not rely on fixtures like "shell" to define the DUT's state.
+    Always ensure the state manually by calling strategy.transition() is needed.
     """
-    stdout = shell.run_check("rauc --version")
-    assert "rauc" in "\n".join(stdout)
+    strategy.transition("barebox")
+    strategy.barebox.run_check("bootchooser -a default -p default")
+
+    yield
+
+    strategy.transition("barebox")
+    strategy.barebox.run_check("bootchooser -a default -p default")
 
 
-def test_rauc_status(shell):
+@pytest.fixture
+def booted_slot(strategy: LXATACStrategy):
     """
-    Test basic slot status readout.
+    Returns booted slot
+
+    Note: Calling the Callable returned by this fixture will transition the DUT in the "shell" state.
     """
-    shell.run_check("rauc status", timeout=60)
+
+    def _booted_slot():
+        strategy.transition("shell")
+        [stdout] = strategy.shell.run_check("rauc status --output-format=json", timeout=60)
+        rauc_status = json.loads(stdout)
+
+        assert "booted" in rauc_status, 'No "booted" key in rauc status JSON found'
+
+        return rauc_status["booted"]
+
+    yield _booted_slot
+
+
+@pytest.fixture
+def set_bootstate_in_bootloader(strategy: LXATACStrategy, default_bootstate):
+    """
+    Sets the given bootchooser parameters
+
+    Note: This fixture changes the state of the DUT using the strategy.
+    When using this fixture do not rely on fixtures like "shell" to define the DUT's state.
+    Always ensure the state manually by calling strategy.transition() is needed.
+    """
+
+    def _set_bootstate(system0_prio, system0_attempts, system1_prio, system1_attempts):
+        strategy.transition("barebox")
+        barebox = strategy.barebox
+
+        barebox.run_check(f"state.bootstate.system0.priority={system0_prio}")
+        barebox.run_check(f"state.bootstate.system0.remaining_attempts={system0_attempts}")
+
+        barebox.run_check(f"state.bootstate.system1.priority={system1_prio}")
+        barebox.run_check(f"state.bootstate.system1.remaining_attempts={system1_attempts}")
+
+        barebox.run_check("state -s")
+
+    yield _set_bootstate
 
 
 @pytest.fixture(scope="function")
@@ -49,6 +96,22 @@ def rauc_cert_enabled(strategy: LXATACStrategy, env: labgrid.Environment):
     yield
     strategy.transition("shell")
     strategy.shell.run_check(f"rauc-disable-cert {cert}")
+
+
+def test_rauc_version(shell):
+    """
+    Test basic availability working of rauc binary by obtaining version
+    information
+    """
+    stdout = shell.run_check("rauc --version")
+    assert "rauc" in "\n".join(stdout)
+
+
+def test_rauc_status(shell):
+    """
+    Test basic slot status readout.
+    """
+    shell.run_check("rauc status", timeout=60)
 
 
 def test_rauc_info_json(shell, rauc_bundle, check, rauc_cert_enabled):

--- a/tests/test_rauc.py
+++ b/tests/test_rauc.py
@@ -95,7 +95,7 @@ def rauc_cert_enabled(strategy: LXATACStrategy, env: labgrid.Environment):
     strategy.shell.run_check(f"rauc-enable-cert {cert}")
     yield
     strategy.transition("shell")
-    strategy.shell.run_check(f"rauc-disable-cert {cert}")
+    strategy.shell.run(f"rauc-disable-cert {cert}")
 
 
 def test_rauc_version(shell):

--- a/tests/test_rauc.py
+++ b/tests/test_rauc.py
@@ -3,6 +3,8 @@ import json
 import labgrid
 import pytest
 
+from lxatacstrategy import LXATACStrategy
+
 """
 Basic rauc tests
 
@@ -36,15 +38,17 @@ def test_rauc_status(shell):
 
 
 @pytest.fixture(scope="function")
-def rauc_cert_enabled(shell, env: labgrid.Environment):
+def rauc_cert_enabled(strategy: LXATACStrategy, env: labgrid.Environment):
     # Bundles during testing are not signed with release keys.
     # But the development key is not enabled by default.
     # So we need to enable it first.
 
     cert = "pengutronix.cert.pem" if "ptx-flavor" in env.get_target_features() else "devel.cert.pem"
-    shell.run_check(f"rauc-enable-cert {cert}")
+    strategy.transition("shell")
+    strategy.shell.run_check(f"rauc-enable-cert {cert}")
     yield
-    shell.run_check(f"rauc-disable-cert {cert}")
+    strategy.transition("shell")
+    strategy.shell.run_check(f"rauc-disable-cert {cert}")
 
 
 def test_rauc_info_json(shell, rauc_bundle, check, rauc_cert_enabled):


### PR DESCRIPTION
The fixtures used in RAUC testing are somewhat special as the fixtures actually modify die DUTs state. This leads to situations where a fixture or test can not rely on one of the state-fixtures (e.g. `shell`) to  bring the device in the correct state.

This PR fixes this problem in the `rauc_cert_enabled`-fixture.
It also refactors the RAUC fixtures into the RAUC module and adds notes on this unexpected behavior.