### PR TITLE
Fix test_rauc_install often failing

### DIFF
--- a/lxatacstrategy.py
+++ b/lxatacstrategy.py
@@ -252,5 +252,6 @@ class LXATACStrategy(Strategy):
             get_info(self.shell, "df --human-readable")
             get_info(self.shell, "free -m")
             get_info(self.shell, "systemctl list-units --failed --no-pager")
+            get_info(self.shell, "rauc status")
 
         return pm_info

--- a/lxatacstrategy.py
+++ b/lxatacstrategy.py
@@ -123,6 +123,9 @@ class LXATACStrategy(Strategy):
                 # coordinator clean up stale resources.
                 self.shell.run("systemctl stop labgrid-exporter", timeout=90)
 
+                # Sync all pending changes to eMMC before switching off power
+                self.shell.run_check("sync")
+
             self.target.deactivate(self.barebox)
             self.target.deactivate(self.shell)
             self.target.deactivate(self.fastboot)

--- a/lxatacstrategy.py
+++ b/lxatacstrategy.py
@@ -167,6 +167,14 @@ class LXATACStrategy(Strategy):
 
             self.target.activate(self.shell)
             self.wait_system_ready()
+
+            # Deactivate automatic update installation:
+            # With no update channels configured the tacd will never enable the automatic installation in RAUC.
+            self.shell.run(
+                'if [ -d "/usr/share/tacd/update_channels" ]; then mv "/usr/share/tacd/update_channels" '
+                '"/usr/share/tacd/update_channels.deactivated" && systemctl restart tacd.service; fi'
+            )
+
             self.wait_online()
 
             # Use shorter boot timeout for subsequent boots.

--- a/lxatacstrategy.py
+++ b/lxatacstrategy.py
@@ -175,6 +175,17 @@ class LXATACStrategy(Strategy):
                 '"/usr/share/tacd/update_channels.deactivated" && systemctl restart tacd.service; fi'
             )
 
+            if self.first_boot:
+                # Devices will be shipped with a certificate configured.
+                # Let's do the same in our testing environment.
+                # (After installation via RAUC the new bundle will activate the matching certificate itself.)
+                cert = (
+                    "pengutronix.cert.pem"
+                    if "ptx-flavor" in self.target.env.get_target_features()
+                    else "devel.cert.pem"
+                )
+                self.shell.run_check(f"rauc-enable-cert {cert}")
+
             self.wait_online()
 
             # Use shorter boot timeout for subsequent boots.

--- a/tests/test_rauc.py
+++ b/tests/test_rauc.py
@@ -1,6 +1,5 @@
 import json
 
-import labgrid
 import pytest
 
 from lxatacstrategy import LXATACStrategy
@@ -84,20 +83,6 @@ def set_bootstate_in_bootloader(strategy: LXATACStrategy, default_bootstate):
     yield _set_bootstate
 
 
-@pytest.fixture(scope="function")
-def rauc_cert_enabled(strategy: LXATACStrategy, env: labgrid.Environment):
-    # Bundles during testing are not signed with release keys.
-    # But the development key is not enabled by default.
-    # So we need to enable it first.
-
-    cert = "pengutronix.cert.pem" if "ptx-flavor" in env.get_target_features() else "devel.cert.pem"
-    strategy.transition("shell")
-    strategy.shell.run_check(f"rauc-enable-cert {cert}")
-    yield
-    strategy.transition("shell")
-    strategy.shell.run(f"rauc-disable-cert {cert}")
-
-
 def test_rauc_version(shell):
     """
     Test basic availability working of rauc binary by obtaining version
@@ -114,7 +99,7 @@ def test_rauc_status(shell):
     shell.run_check("rauc status", timeout=60)
 
 
-def test_rauc_info_json(shell, rauc_bundle, check, rauc_cert_enabled):
+def test_rauc_info_json(shell, rauc_bundle, check):
     """
     Test rauc info output in JSON for a rauc bundle read via http.
     """
@@ -139,9 +124,7 @@ def test_rauc_info_json(shell, rauc_bundle, check, rauc_cert_enabled):
 
 @pytest.mark.slow
 @pytest.mark.dependency()
-def test_rauc_install(
-    strategy, booted_slot, set_bootstate_in_bootloader, rauc_bundle, log_duration, rauc_cert_enabled
-):
+def test_rauc_install(strategy, booted_slot, set_bootstate_in_bootloader, rauc_bundle, log_duration):
     """
     Test if a rauc install from slot0 into slot1 works.
     """


### PR DESCRIPTION
This PR combines a set of measures intended to fix `test_rauc_install` often failing.

The root cause for the fail seems to be that enabling the correct cert directly before power off leads to situations where this change may not have been synced to eMMC and thus gets lost.
So add a `sync` before power off the device from `shell`.

But while we are on it: Overhaul a little more of the certificate and update-channel handling:

* Make sure automatic updates are disabled on all flavors.
* Enable a RAUC certificate at first boot, just like end-of-line bring-up does.
* And also add `rauc status` to the post-mortem infodump.