### PR TITLE
Tests: Linux Log: Filter Journal Messages

### DIFF
--- a/tests/test_linux_log.py
+++ b/tests/test_linux_log.py
@@ -41,7 +41,16 @@ def test_kernel_messages(shell):
         "usb usb1-port3: cannot reset (err = -32)",
     }
 
+    allowed_re = [
+        # These messages can happen depending on the order tests and are harmless
+        re.compile(
+            r"^systemd-journald.+File \/var\/log\/journal.+ corrupted or uncleanly shut down, renaming and replacing.$"
+        ),
+    ]
+
     messages = shell.run_check("dmesg -l warn -l err -l crit -l alert -l emerg")
     messages = set(re.sub(r"^\[\s*\d+\.\d+\] ", "", m) for m in messages)
+
+    messages = {m for m in messages if not any(r.match(m) for r in allowed_re)}
 
     assert messages - allowed == expected


### PR DESCRIPTION
Depending on the order of tests (e.g. if the LXA TAC has been re-booted before `tedt_kernel_messages()` is run a message like the following may appear in the kernel log:

`[   13.835642] systemd-journald[148]: File /var/log/journal/b6b2389c60ca47e882ee2e4292ce1ba8/system.journal corrupted or uncleanly shut down, renaming and replacing.`

These are harmless and can be ignored.
Since the actual path may vary introduce a new regex-based match to drop these messages from the set of messages before comparison.